### PR TITLE
adds notify_callback key to setup table to override default notify

### DIFF
--- a/lua/cmp_ai/config.lua
+++ b/lua/cmp_ai/config.lua
@@ -5,7 +5,11 @@ local conf = {
   run_on_every_keystroke = true,
   provider = 'HF',
   notify = true,
-  ignored_file_types = { -- default is not to ignore
+  notify_callback = function(msg)
+    vim.notify(msg)
+  end,
+  ignored_file_types = {
+    -- default is not to ignore
     -- uncomment to ignore in lua:
     -- lua = true
   },

--- a/lua/cmp_ai/source.lua
+++ b/lua/cmp_ai/source.lua
@@ -16,7 +16,7 @@ end
 
 function Source:_do_complete(ctx, cb)
   if conf:get('notify') then
-    vim.notify('Completion started')
+    conf:get('notify_callback')('Completion started')
   end
   local max_lines = conf:get('max_lines')
   local cursor = ctx.context.cursor
@@ -41,7 +41,7 @@ function Source:_do_complete(ctx, cb)
   service:complete(before, after, function(data)
     self:end_complete(data, ctx, cb)
     if conf:get('notify') then
-      vim.notify('Completion done')
+      conf:get('notify_callback')('Completion started')
     end
   end)
 end


### PR DESCRIPTION
I would like to be able to pass in a different notifier like [notify](https://github.com/rcarriga/nvim-notify):

```lua
cmp_ai:setup({
  max_lines = 1000,
  provider = "OpenAI",
  model = "gpt-3.5-turbo",
  notify = true,
  notify_callback = function(msg)
    require("notify").notify(msg, vim.log.levels.INFO, {
      title = "OpenAI",
    })
  end,
  run_on_every_keystroke = true,
  ignored_file_types = {
	  -- default is not to ignore
	  -- uncomment to ignore in lua:
	  -- lua = true
  },
})

```