### PR TITLE
add more data to format item table for better lspkind integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,41 +242,23 @@ You can use the following to pretty print the completion menu (requires
 (<https://www.nerdfonts.com>)):
 
 ```lua
-local lspkind = require('lspkind')
-
-local source_mapping = {
-  buffer = '[Buffer]',
-  nvim_lsp = '[LSP]',
-  nvim_lua = '[Lua]',
-  cmp_ai = '[AI]',
-  path = '[Path]',
-}
-
 require('cmp').setup({
   sources = {
     { name = 'cmp_ai' },
   },
   formatting = {
-    format = function(entry, vim_item)
-      -- if you have lspkind installed, you can use it like
-      -- in the following line:
-      vim_item.kind = lspkind.symbolic(vim_item.kind, { mode = 'symbol' })
-      vim_item.menu = source_mapping[entry.source.name]
-      if entry.source.name == 'cmp_ai' then
-        local detail = (entry.completion_item.labelDetails or {}).detail
-        vim_item.kind = ''
-        if detail and detail:find('.*%%.*') then
-          vim_item.kind = vim_item.kind .. ' ' .. detail
-        end
-
-        if (entry.completion_item.data or {}).multiline then
-          vim_item.kind = vim_item.kind .. ' ' .. '[ML]'
-        end
-      end
-      local maxwidth = 80
-      vim_item.abbr = string.sub(vim_item.abbr, 1, maxwidth)
-      return vim_item
-    end,
+    format = require('lspkind').cmp_format({
+      mode = "symbol_text",
+      maxwidth = 50,
+      ellipsis_char = '...',
+      show_labelDetails = true,
+      symbol_map = {
+        HF = "",
+        OpenAI = "",
+        Codestral = "",
+        Bard = "",
+      }
+    });
   },
 })
 ```

--- a/lua/cmp_ai/config.lua
+++ b/lua/cmp_ai/config.lua
@@ -22,7 +22,9 @@ function M:setup(params)
   end
   local status, provider = pcall(require, 'cmp_ai.backends.' .. conf.provider:lower())
   if status then
+    local name = conf.provider
     conf.provider = provider:new(conf.provider_options)
+    conf.provider.name = name
   else
     vim.notify('Bad provider in config: ' .. conf.provider, vim.log.levels.ERROR)
   end

--- a/lua/cmp_ai/source.lua
+++ b/lua/cmp_ai/source.lua
@@ -61,6 +61,10 @@ function Source:end_complete(data, ctx, cb)
     local prefix = string.sub(ctx.context.cursor_before_line, ctx.offset)
     local result = prefix .. response
     table.insert(items, {
+      cmp = {
+        kind_hl_group = 'CmpItemKind' .. conf:get('provider').name,
+        kind_text = conf:get('provider').name,
+      },
       label = result,
       documentation = {
         kind = cmp.lsp.MarkupKind.Markdown,


### PR DESCRIPTION
[supermaven-nvim](https://github.com/supermaven-inc/supermaven-nvim/blob/c8c05aff5f6925568a6973b94578c73382c80f0e/lua/supermaven-nvim/cmp.lua#L87), [codeium-nvim](https://github.com/Exafunction/codeium.nvim/blob/f6a2ef32a9e923cb0104a19d3e426b0e40e49505/lua/codeium/source.lua#**L68**) and [copilot](https://github.com/zbirenbaum/copilot-cmp/blob/b6e5286b3d74b04256d0a7e3bd2908eabec34b44/lua/copilot_cmp/format.lua#L157) all define a `kind_hl_group` and `kind_text` in the format item for nvim-cmp, cmp-ai contains less fields in the format item.

As part of `nvim-cmp` setup using [lspkind](https://github.com/onsails/lspkind.nvim) I can set symbols based on `kind_text`
```
cmp.setup({
  formatting = {
    fields = {'menu', 'abbr', 'kind'},
    format = require('lspkind').cmp_format({
      mode = "symbol",
      maxwidth = 50,
      ellipsis_char = '...',
      symbol_map = {
        Supermaven = "", -- "",
        Codeium = "",
        Copilot = "", -- ",
        Codestral = "",
      },
    })
  },
})
```

I'd like to be able to do the same for different `cmp-ai` providers. This commit sets the additional `cmp` data on the format item table for `nvim-ai`, it defaults to 'CmpAI' so you can easily set all `nvim-ai` providers to use the same icon, or by  setting the `cmp-ai` config `use_provider_as_kind_text` to true it'll use the providers name.