### PR TITLE
feat: add support for suffix parameter in ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # cmp-ai
 
+
 AI source for [hrsh7th/nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 
 This is a general purpose AI source for `cmp`, easily adapted to any restapi
@@ -166,6 +167,31 @@ cmp_ai:setup({
     -- uncomment to ignore in lua:
     -- lua = true
   },
+})
+```
+
+With Ollama you can also use the `suffix` parameter, typically when you want to use cmd-ai for codecompletion.  
+
+```lua
+local cmp_ai = require('cmp_ai.config')
+
+cmp_ai:setup({
+  max_lines = 100,
+  provider = 'Ollama',
+  provider_options = {
+    model = 'codellama:7b-code',
+    prompt = function(lines_before, lines_after)
+        return lines_before
+    end,
+    suffix = function(lines_after)
+      return lines_after
+    end,
+  },
+  notify = true,
+  notify_callback = function(msg)
+    vim.notify(msg)
+  end,
+  run_on_every_keystroke = true,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ cmp_ai:setup({
 })
 ```
 
-With Ollama you can also use the `suffix` parameter, typically when you want to use cmd-ai for codecompletion.  
+With Ollama you can also use the `suffix` parameter, typically when you want to use cmp-ai for codecompletion.  
 
 ```lua
 local cmp_ai = require('cmp_ai.config')

--- a/README.md
+++ b/README.md
@@ -170,7 +170,17 @@ cmp_ai:setup({
 })
 ```
 
-With Ollama you can also use the `suffix` parameter, typically when you want to use cmp-ai for codecompletion.  
+With Ollama you can also use the `suffix` parameter, typically when you want to use cmp-ai for codecompletion and you want to use the default plugin/prompt.  
+
+If the model you're using has the following template:
+```
+{{- if .Suffix }}<|fim_prefix|>{{ .Prompt }}<|fim_suffix|>{{ .Suffix }}<|fim_middle|>
+{{- else }}{{ .Prompt }}
+{{- end }}
+```
+then you can use the suffix parameter to not change the prompt. since the model will use your suffix and the prompt to construct the template.
+The prompts should be the `lines_before` and suffix the `lines_after`
+Now you can even change the model without the need to adjust the prompt or suffix functions.
 
 ```lua
 local cmp_ai = require('cmp_ai.config')
@@ -179,7 +189,7 @@ cmp_ai:setup({
   max_lines = 100,
   provider = 'Ollama',
   provider_options = {
-    model = 'codellama:7b-code',
+    model = 'codegemma:2b-code',
     prompt = function(lines_before, lines_after)
         return lines_before
     end,

--- a/lua/cmp_ai/backends/ollama.lua
+++ b/lua/cmp_ai/backends/ollama.lua
@@ -25,6 +25,7 @@ function Ollama:complete(lines_before, lines_after, cb)
     template = self.params.template,
     system = self.params.system,
     stream = false,
+    suffix = self.params.suffix and self.params.suffix(lines_after),
     options = self.params.options,
   }
 


### PR DESCRIPTION
## What does this PR do?
This PR adds support for the suffix parameter in Ollama. 
The ollama API does support a suffix parameter for FIM requests/models: https://github.com/ollama/ollama/blob/main/docs/api.md#parameters


Via a function call similar to the prompts we can add the suffix which typically would be `lines_after`.
usage:
```lua
provider_options = {
    suffix = function(lines_after)
        return lines_after
    end,
}
```
For example codegemma a popular FIM model has the following template:
```
{{- if .Suffix }}<|fim_prefix|>{{ .Prompt }}<|fim_suffix|>{{ .Suffix }}<|fim_middle|>
{{- else }}{{ .Prompt }}
{{- end }}
```
this allows us to use the suffix and not change the template

Support was added here: https://github.com/ollama/ollama/pull/5207