### PR TITLE
Shallow copy headers to avoid mutating the original

### DIFF
--- a/lua/cmp_ai/requests.lua
+++ b/lua/cmp_ai/requests.lua
@@ -26,7 +26,7 @@ function Service:json_decode(data)
 end
 
 function Service:Get(url, headers, data, cb)
-  headers = headers or {}
+  headers = vim.tbl_extend("force", {}, headers or {})
   headers[#headers + 1] = 'Content-Type: application/json'
 
   local tmpfname = os.tmpname()


### PR DESCRIPTION
With Codestral and maybe other backends the same headers are passed to Get for every request. Without this change for each request an additional Content-Type header is added. Codestral fails when multiple Content-Type headers are present.

For example when using Codestral I generated the folloing curl args
```
{ "https://codestral.mistral.ai/v1/fim/completions", "-d", "@/tmp/lua_vZiQ6f", "-H", "Authorization: Bearer ***********************", "-H", "Content-Type: application/json", "-H", "Content-Type: application/json", "-H", "Content-Type: application/json", "-H", "Content-Type: application/json" }
```

And I get the response:
```
{\n  code = vim.NIL,\n  message = "Input should be a valid dictionary or object to extract fields from",\n  object = "error",\n  param = vim.NIL,\n  type = "invalid_request_error"\n}
```

This commit makes a shallow copy of the headers before adding additional headers