### PR TITLE
feat: save the raw response for debugging purpose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,23 @@ cmp.setup({
   },
 })
 ```
+
+## Debugging Information
+
+To retrieve the raw response from the backend, you can set the following option
+in `provider_options`: 
+```lua
+provider_options = {
+  raw_response_cb = function(response)
+    -- the `response` parameter contains the raw response (JSON-like) object.
+
+    vim.notify(vim.inspect(response)) -- show the response as a lua table
+
+    vim.g.ai_raw_response = response -- store the raw response in a global
+                                     -- variable so that you can use it
+                                     -- somewhere else (like statusline).
+  end,
+}
+```
+This provides useful information like context lengths (# of tokens) and 
+generation speeds (tokens per seconds), depending on your backend. 

--- a/lua/cmp_ai/requests.lua
+++ b/lua/cmp_ai/requests.lua
@@ -57,8 +57,8 @@ function Service:Get(url, headers, data, cb)
 
         local result = table.concat(response:result(), '\n')
         local json = self:json_decode(result)
-        if type(self.raw_response_cb) == 'function' then
-          self.raw_response_cb(json)
+        if type(self.params.raw_response_cb) == 'function' then
+          self.params.raw_response_cb(json)
         end
         if json == nil then
           cb({ { error = 'No Response.' } })

--- a/lua/cmp_ai/requests.lua
+++ b/lua/cmp_ai/requests.lua
@@ -57,6 +57,7 @@ function Service:Get(url, headers, data, cb)
 
         local result = table.concat(response:result(), '\n')
         local json = self:json_decode(result)
+        self:save_response(json)
         if json == nil then
           cb({ { error = 'No Response.' } })
         else
@@ -67,4 +68,9 @@ function Service:Get(url, headers, data, cb)
     :start()
 end
 
+function Service:save_response(response)
+  vim.schedule(function()
+    require('cmp_ai').raw_response = response
+  end)
+end
 return Service

--- a/lua/cmp_ai/requests.lua
+++ b/lua/cmp_ai/requests.lua
@@ -57,7 +57,9 @@ function Service:Get(url, headers, data, cb)
 
         local result = table.concat(response:result(), '\n')
         local json = self:json_decode(result)
-        self:save_response(json)
+        if type(self.raw_response_cb) == 'function' then
+          self.raw_response_cb(json)
+        end
         if json == nil then
           cb({ { error = 'No Response.' } })
         else
@@ -68,9 +70,4 @@ function Service:Get(url, headers, data, cb)
     :start()
 end
 
-function Service:save_response(response)
-  vim.schedule(function()
-    require('cmp_ai').raw_response = response
-  end)
-end
 return Service


### PR DESCRIPTION
This gives users access to the raw response from the backend. I use cmp-ai with Ollama backend, and with this PR I can see the context length and generation speeds etc. which helps me figure out the optimal model and parameters to use. I haven't updated the readme because I wasn't sure about the implication it might have on the other backends, and it would be nice if someone with access to other backends could take a look.