### PR TITLE
feat: implement auto_unload for ollama backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cmp_ai:setup({
   provider = 'Ollama',
   provider_options = {
     model = 'codellama:7b-code',
-    auto_unload = true, -- Set to true to automatically unload the model when
+    auto_unload = false, -- Set to true to automatically unload the model when
                         -- exiting nvim.
   },
   notify = true,

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ cmp_ai:setup({
   provider = 'Ollama',
   provider_options = {
     model = 'codellama:7b-code',
+    auto_unload = true, -- Set to true to automatically unload the model when
+                        -- exiting nvim.
   },
   notify = true,
   notify_callback = function(msg)

--- a/lua/cmp_ai/backends/ollama.lua
+++ b/lua/cmp_ai/backends/ollama.lua
@@ -13,7 +13,14 @@ function Ollama:new(o)
       temperature = 0.2,
     },
   })
-
+  if self.params.auto_unload then
+    vim.api.nvim_create_autocmd('VimLeave', {
+      callback = function()
+        self:Get(self.params.base_url, {}, { model = self.params.model, keep_alive = 0 }, function() end)
+      end,
+      group = vim.api.nvim_create_augroup('CmpAIOllama', { clear = true }),
+    })
+  end
   return o
 end
 


### PR DESCRIPTION
This PR adds an option to the `ollama` backend to automatically unload the model from the ollama host on `VimLeave` to free up the RAM/VRAM. The unloading is achieved by sending a request to the ollama host with the `keep_alive` option set to `0`, [as documented in the ollama documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#unload-a-model).