### PR TITLE
allow `notify_callback` to invoke `on_start` and `on_end` callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,39 @@ notify_callback = function(msg)
 end
 ```
 
+If you want, you can also configure callbacks for `on_start` and `on_end` events
+
+```lua
+notify_callback = {
+    on_start = function(msg)
+        require('notify').notify(
+            msg .. "completion started",
+            vim.log.levels.INFO,
+            {
+                title = 'OpenAI',
+                render = 'compact',
+            }
+        )
+
+        -- do pretty animations or something here
+    end,
+
+    on_end = function(msg)
+        require('notify').notify(
+            msg .. "completion ended",
+            vim.log.levels.INFO,
+            {
+                title = 'OpenAI',
+                render = 'compact',
+            }
+        )
+
+        -- finish pretty animations started above
+    end,
+}
+```
+
+
 ### `max_lines`
 
 How many lines of buffer context to use

--- a/doc/cmp-ai.txt
+++ b/doc/cmp-ai.txt
@@ -349,6 +349,35 @@ configured.For example:
     end
 <
 
+If you want, you can also configure callbacks for `on_start` and `on_end` events
+
+>lua
+    notify_callback = {
+	on_start = function(msg)
+	    require('notify').notify(
+		msg .. "completion started",
+		vim.log.levels.INFO,
+		{
+		    title = 'OpenAI',
+		    render = 'compact',
+		}
+	    )
+	    -- do pretty animations or something here
+	end,
+
+	on_end = function(msg)
+	    require('notify').notify(
+		msg .. "completion ended",
+		vim.log.levels.INFO,
+		{
+		    title = 'OpenAI',
+		    render = 'compact',
+		}
+	    )
+	    -- finish pretty animations started above
+	end,
+    }
+
 
 MAX_LINES ~
 


### PR DESCRIPTION
great plugin! I have it working locally and it's great.

I've been toying around with getting notifications to work w/ this and found `notify_callback` a bit confusing so I wanted to contribute back, take a stab at fleshing out this feature.

list of changes:

- `notify_callback` sent the wrong message on end (it said `Starting` for both invocations)
- optionally allow `notify_callback` to be a table
- table supports `on_start` and `on_end` events (sending the same messages as before)
- if `notify_callback` is not a table, original behavior is the same
- ...except that we also pass in a `boolean` differentiating whether we `started?` or not

if this isn't something you do not want to support though no worries, feel free to close! thanks again

My notification plugin of choice is https://github.com/rcarriga/nvim-notify

example of how I'm using these changes in my fork

![ai-omg](https://github.com/user-attachments/assets/8beb7d1b-eb94-4484-ad94-5b4412c2338a)