### PR TITLE
feat: `max_timeout_seconds` for `curl` based sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,19 @@ notify_callback = {
 }
 ```
 
+### log_errors
+
+Log any errors that the AI backend returns. Defaults to `true`. This does not
+prevent the notification callbacks from being called; you can set this to
+`false` to prevent excess noise if you perform other `vim.notify` calls in
+your callbacks.
+
+```lua
+cmp_ai:setup({
+    log_errors = true,
+})
+```
+
 
 ### `max_lines`
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,19 @@ cmp_ai:setup({
 
 How many lines of buffer context to use
 
+### `max_timeout_seconds`
+
+Number of seconds before a code completion request is cancelled. Bard is
+currently not supported. This is `--max-time` for `curl`.
+
+example:
+
+```lua
+cmp_ai:setup({
+  max_timeout_seconds = 8,
+})
+```
+
 ### `run_on_every_keystroke`
 
 Generate new completion items on every keystroke.

--- a/doc/cmp-ai.txt
+++ b/doc/cmp-ai.txt
@@ -384,6 +384,18 @@ MAX_LINES ~
 How many lines of buffer context to use
 
 
+LOG_ERRORS
+
+Log any errors that the AI backend returns. Defaults to `true`. This does not
+prevent the notification callbacks from being called; you can set this to
+`false` to prevent excess noise if you perform other `vim.notify` calls in
+your callbacks.
+
+>lua
+    cmp_ai:setup({
+      log_errors = true,
+    })
+
 RUN_ON_EVERY_KEYSTROKE ~
 
 Generate new completion items on every keystroke.

--- a/doc/cmp-ai.txt
+++ b/doc/cmp-ai.txt
@@ -383,6 +383,18 @@ MAX_LINES ~
 
 How many lines of buffer context to use
 
+MAX_TIMEOUT_SECONDS
+
+Number of seconds before a code completion request is cancelled. Bard is
+currently not supported. This is `--max-time` for `curl`.
+
+example:
+
+>lua
+    cmp_ai:setup({
+      max_timeout_seconds = 8,
+    })
+
 
 LOG_ERRORS
 
@@ -495,7 +507,6 @@ You can bump `cmp-ai` completions to the top of your completion menu like so:
       },
     })
 <
-
 
 DEBUGGING INFORMATION                    *cmp-ai-cmp-ai-debugging-information*
 

--- a/lua/cmp_ai/config.lua
+++ b/lua/cmp_ai/config.lua
@@ -14,6 +14,8 @@ local conf = {
     -- uncomment to ignore in lua:
     -- lua = true
   },
+
+  log_errors = true,
 }
 
 function M:setup(params)


### PR DESCRIPTION
when running this plugin, even with `run_on_every_keystroke = false`, my machine gets flooded with `curl` requests to the backing service.

this is an admittedly naive approach at trying to cancel previous requests when many keystrokes and events are being sent to lessen/decrease machine load

also adding a `log_errors` flag that defaults to true; I have my own notification loop/workflow (per #39) and the default error notification callback makes things very messy